### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ const mapCopy = map; // Look, "copies" are free!
 ```
 
 [React]: http://facebook.github.io/react/
-[Flux]: http://facebook.github.io/flux/docs/overview.html
+[Flux]: http://facebook.github.io/flux/docs/overview/
 
 
 JavaScript-first API


### PR DESCRIPTION
Hi,

This PR is no big deal really. Just thought wrong URL to Flux documentation in readme might cause discomfort to people who read it. So I updated it. 